### PR TITLE
declare bannerState outside collapsed cookie check

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -82,8 +82,9 @@ function addClickEvents(cookieExpDate) {
     $('.d-icon-chevron-up').toggle();
 
     if(cookieExpDate) {
+      let bannerState
       if($.cookie("banner_collapsed")) {
-        let bannerState = JSON.parse($.cookie('banner_collapsed'));
+        bannerState = JSON.parse($.cookie('banner_collapsed'));
         bannerState.name = settings.cookie_name;
         if(bannerState.collapsed == "false") {
           bannerState.collapsed = "true";

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -82,7 +82,7 @@ function addClickEvents(cookieExpDate) {
     $('.d-icon-chevron-up').toggle();
 
     if(cookieExpDate) {
-      let bannerState
+      let bannerState;
       if($.cookie("banner_collapsed")) {
         bannerState = JSON.parse($.cookie('banner_collapsed'));
         bannerState.name = settings.cookie_name;


### PR DESCRIPTION
The banner_collapsed cookie was never being updated on click events since the let bannerState declaration happened within the if block checking that a cookie already exists.

Feel free to dismiss this pull request since it is such a simple change. And thanks for the great theme component!