### PR TITLE
UX: vertical scrollbar improvements 

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -183,8 +183,8 @@
 ////////////// Full Width //////////////
 
 @if $full_width_banner == "true" {
-  body {
-    overflow-x: hidden; // Needed to compensate for the overflow caused by the vertical scrollbar
+  #main {
+    overflow: hidden; // Needed to compensate for the overflow caused by the vertical scrollbar
 
     .banner-box {
       margin-top: -2em;

--- a/common/common.scss
+++ b/common/common.scss
@@ -54,11 +54,13 @@
     }
   }
 
-  h1, h2, h3 {
+  h1,
+  h2,
+  h3 {
     text-align: center;
     color: $secondary_text_color;
   }
-  
+
   a {
     color: $link_text_color;
   }


### PR DESCRIPTION
This PR moves the CSS overflow property from the `<body>` tag to `#main` to address some cases where the spinner causes vertical scrollbars.

This PR is not supposed to cause any visual changes to how the banner looks.