### PR TITLE
FIX: Refactor cookie handling, tests

### DIFF
--- a/javascripts/discourse/components/versatile-banner.gjs
+++ b/javascripts/discourse/components/versatile-banner.gjs
@@ -11,23 +11,53 @@ import { and } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import VersatileBannerColumn from "./versatile-banner-column";
 
+function readBannerCookie(name) {
+  const value = cookie(name);
+
+  if (!value) {
+    return null;
+  }
+
+  if (settings.cookie_lifespan === "none") {
+    removeCookie(name, { path: "/" });
+    return null;
+  }
+
+  let state;
+  try {
+    state = JSON.parse(value);
+  } catch {
+    removeCookie(name, { path: "/" });
+    return null;
+  }
+
+  if (state?.name !== settings.cookie_name) {
+    removeCookie(name, { path: "/" });
+    return null;
+  }
+
+  return state;
+}
+
+function readBannerCollapsed() {
+  const state = readBannerCookie("banner_collapsed");
+
+  if (!state) {
+    return null;
+  }
+
+  return state.collapsed === true || state.collapsed === "true";
+}
+
 export default class VersatileBanner extends Component {
   @service router;
   @service currentUser;
 
-  @tracked bannerClosed = this.cookieClosed || false;
+  @tracked bannerClosed = readBannerCookie("banner_closed")?.closed === "true";
   @tracked
   bannerCollapsed =
-    this.collapsedFromCookie !== null
-      ? this.collapsedFromCookie
-      : this.isDefaultCollapsed;
+    readBannerCollapsed() ?? settings.default_collapsed_state === "collapsed";
 
-  cookieClosed = cookie("banner_closed");
-  cookieCollapsed = cookie("banner_collapsed");
-  isDefaultCollapsed = settings.default_collapsed_state === "collapsed";
-  collapsedFromCookie = this.cookieCollapsed
-    ? JSON.parse(this.cookieCollapsed).collapsed
-    : null;
   columnData = [
     {
       content: settings.first_column_content,
@@ -58,11 +88,10 @@ export default class VersatileBanner extends Component {
 
   get cookieExpirationDate() {
     if (settings.cookie_lifespan === "none") {
-      removeCookie("banner_closed", { path: "/" });
-      removeCookie("banner_collapsed", { path: "/" });
-    } else {
-      return moment().add(1, settings.cookie_lifespan).toDate();
+      return null;
     }
+
+    return moment().add(1, settings.cookie_lifespan).toDate();
   }
 
   get displayForUser() {
@@ -123,24 +152,18 @@ export default class VersatileBanner extends Component {
   @action
   toggleBanner() {
     this.bannerCollapsed = !this.bannerCollapsed;
-    let bannerState = {
-      name: settings.cookie_name,
-      collapsed: this.bannerCollapsed,
-    };
 
     if (this.cookieExpirationDate) {
-      if (this.cookieCollapsed) {
-        bannerState = JSON.parse(this.cookieCollapsed);
-        bannerState.collapsed = this.bannerCollapsed;
-      }
-    } else {
-      bannerState.collapsed = this.bannerCollapsed;
-    }
+      const bannerState = {
+        name: settings.cookie_name,
+        collapsed: this.bannerCollapsed,
+      };
 
-    cookie("banner_collapsed", JSON.stringify(bannerState), {
-      expires: this.cookieExpirationDate,
-      path: "/",
-    });
+      cookie("banner_collapsed", JSON.stringify(bannerState), {
+        expires: this.cookieExpirationDate,
+        path: "/",
+      });
+    }
   }
 
   <template>

--- a/test/acceptance/versatile-banner-test.js
+++ b/test/acceptance/versatile-banner-test.js
@@ -2,6 +2,23 @@ import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
+function setBannerCookie(name, state) {
+  document.cookie = `${name}=${encodeURIComponent(
+    JSON.stringify(state)
+  )}; path=/;`;
+}
+
+function hasBannerCookie(name) {
+  return document.cookie
+    .split("; ")
+    .some((entry) => entry.startsWith(`${name}=`));
+}
+
+function clearBannerCookies() {
+  document.cookie = "banner_closed=; path=/; max-age=0";
+  document.cookie = "banner_collapsed=; path=/; max-age=0";
+}
+
 acceptance("Versatile Banner - Logged out", function () {
   test("banner can be hidden from anons", async function (assert) {
     settings.show_for_anon = false;
@@ -117,5 +134,139 @@ acceptance("Versatile Banner - Visibility", function () {
     await click(".banner-box button.close");
 
     assert.dom(".banner-box").doesNotExist("the banner can be dismissed");
+  });
+});
+
+acceptance("Versatile Banner - Cookie state", function (needs) {
+  needs.hooks.beforeEach(function () {
+    clearBannerCookies();
+    settings.show_for_anon = true;
+    settings.cookie_lifespan = "week";
+  });
+
+  test("a matching closed cookie hides the banner", async function (assert) {
+    settings.cookie_name = "v1";
+    setBannerCookie("banner_closed", { name: "v1", closed: "true" });
+
+    await visit("/");
+
+    assert.dom(".banner-box").doesNotExist("the banner stays dismissed");
+  });
+
+  test("a stale closed cookie brings the banner back", async function (assert) {
+    settings.cookie_name = "v2";
+    setBannerCookie("banner_closed", { name: "v1", closed: "true" });
+
+    await visit("/");
+
+    assert
+      .dom(".banner-box")
+      .exists("changing cookie_name re-displays a dismissed banner");
+  });
+
+  test("a matching collapsed cookie collapses the banner", async function (assert) {
+    settings.collapsible = true;
+    settings.default_collapsed_state = "expanded";
+    settings.cookie_name = "v1";
+    setBannerCookie("banner_collapsed", { name: "v1", collapsed: true });
+
+    await visit("/");
+
+    assert.dom(".--banner-collapsed").exists("the banner stays collapsed");
+  });
+
+  test("a stale collapsed cookie falls back to the default state", async function (assert) {
+    settings.collapsible = true;
+    settings.default_collapsed_state = "expanded";
+    settings.cookie_name = "v2";
+    setBannerCookie("banner_collapsed", { name: "v1", collapsed: true });
+
+    await visit("/");
+
+    assert
+      .dom(".--banner-collapsed")
+      .doesNotExist("changing cookie_name re-expands a collapsed banner");
+  });
+
+  test("a malformed cookie is ignored", async function (assert) {
+    settings.cookie_name = "v1";
+    document.cookie = "banner_closed=not-json; path=/;";
+
+    await visit("/");
+
+    assert.dom(".banner-box").exists("the banner renders instead of erroring");
+    assert.false(hasBannerCookie("banner_closed"), "the bad cookie is cleared");
+  });
+
+  test("a stale cookie is cleared rather than left to expire", async function (assert) {
+    settings.cookie_name = "v2";
+    setBannerCookie("banner_closed", { name: "v1", closed: "true" });
+
+    await visit("/");
+
+    assert.false(
+      hasBannerCookie("banner_closed"),
+      "the stale cookie is removed"
+    );
+  });
+
+  test("widget-era string values are honoured", async function (assert) {
+    settings.collapsible = true;
+    settings.default_collapsed_state = "expanded";
+    settings.cookie_name = "v1";
+    setBannerCookie("banner_collapsed", { name: "v1", collapsed: "true" });
+
+    await visit("/");
+
+    assert
+      .dom(".--banner-collapsed")
+      .exists('a legacy collapsed: "true" cookie still collapses the banner');
+  });
+
+  test('widget-era collapsed: "false" does not collapse the banner', async function (assert) {
+    settings.collapsible = true;
+    settings.default_collapsed_state = "collapsed";
+    settings.cookie_name = "v1";
+    setBannerCookie("banner_collapsed", { name: "v1", collapsed: "false" });
+
+    await visit("/");
+
+    assert
+      .dom(".--banner-collapsed")
+      .doesNotExist('the string "false" is not treated as truthy');
+  });
+});
+
+acceptance("Versatile Banner - Cookie lifespan none", function (needs) {
+  needs.hooks.beforeEach(function () {
+    clearBannerCookies();
+    settings.show_for_anon = true;
+    settings.cookie_name = "v1";
+    settings.cookie_lifespan = "none";
+  });
+
+  test("existing cookies are discarded on load", async function (assert) {
+    setBannerCookie("banner_closed", { name: "v1", closed: "true" });
+
+    await visit("/");
+
+    assert
+      .dom(".banner-box")
+      .exists("the banner is not suppressed by a cookie");
+    assert.false(hasBannerCookie("banner_closed"), "the cookie is removed");
+  });
+
+  test("collapsing does not write a cookie", async function (assert) {
+    settings.collapsible = true;
+    settings.default_collapsed_state = "expanded";
+
+    await visit("/");
+    await click(".banner-box button.toggle");
+
+    assert.dom(".--banner-collapsed").exists("the banner collapses in-session");
+    assert.false(
+      hasBannerCookie("banner_collapsed"),
+      "no collapsed cookie is persisted"
+    );
   });
 });


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/versatile-banner/109133/375?u=awesomerobot

Some of the cookie functionality around dismissing the banner has been broken for a while now, this refactors it and gets it working again. 

Mainly: 
* cookie_name did nothing, so it couldn't be bumped to re-show the banner 
* dismissal cookies were being ignored entirely 

This also includes some specs so we can avoid regressions in the future 